### PR TITLE
Add selection order number to individual points

### DIFF
--- a/src/components/PatternLock.js
+++ b/src/components/PatternLock.js
@@ -56,7 +56,7 @@ class PatternLock extends PureComponent {
 		pointColor      : "#FFF",
 		pointSize       : 10,
 		pointActiveSize : 30,
-		
+
 		connectorWidth          : 2,
 		connectorColor          : "#FFF",
 		connectorRoundedCorners : false,
@@ -340,7 +340,9 @@ class PatternLock extends PureComponent {
 		} = this.props;
 
 		return this.points.map((x, i) => {
-			const isActive = this.state.path.indexOf(i) > -1;
+			const activeIndex = this.state.path.indexOf(i);
+			const isActive = activeIndex > -1;
+			const orderNumber = isActive ? activeIndex + 1 : null;
 			const percentPerItem = 100 / size;
 
 			return (
@@ -367,6 +369,7 @@ class PatternLock extends PureComponent {
 								minHeight     : pointSize,
 								background : this.getColor(pointColor, isActive)
 							}}
+							data-order-number={orderNumber}
 						/>
 					</div>
 				</div>


### PR DESCRIPTION
The reason for making this change is that I want to show the selection order visually on top of the pattern.

The order number is added as a data attribute to active (selected) points.

Example CSS code that may be used to show the order number on top of the point:

```css
.react-pattern-lock__point > div {
    z-index: 2;
}

.react-pattern-lock__point > .active::after {
    content: attr(data-order-number);
    color: #333;
    display: block;
    font-size: 16px;
    font-weight: bold;
    text-align: center;
}
```